### PR TITLE
fix(types): replace `@type` with `@class` annotation for `mp` declation

### DIFF
--- a/types/init.lua
+++ b/types/init.lua
@@ -1,2 +1,2 @@
----@type mp
+---@class mp
 _G.mp = nil


### PR DESCRIPTION
Replace the `---@type mp` annotation with `---@class mp` to resolve field injection error.